### PR TITLE
cleanup & fixes to Chord and Scale

### DIFF
--- a/src/chordinnate/musictheory/pitch/Pitch.java
+++ b/src/chordinnate/musictheory/pitch/Pitch.java
@@ -599,8 +599,9 @@ public enum Pitch
             }
             else return candidate;
         }
-
-        return null; // Returned on error
+        else {
+            return null; // Returned on error
+        }
     }
 
     @Override

--- a/src/chordinnate/musictheory/pitch/interval/set/Chord.java
+++ b/src/chordinnate/musictheory/pitch/interval/set/Chord.java
@@ -1,6 +1,5 @@
 package chordinnate.musictheory.pitch.interval.set;
 
-import chordinnate.musictheory.general.Accidental;
 import chordinnate.musictheory.pitch.Pitch;
 import chordinnate.musictheory.pitch.PitchClass;
 import chordinnate.musictheory.pitch.interval.Octave;
@@ -17,32 +16,9 @@ public final class Chord extends NonSerialIntervalSet
     Octave[] uninvertedOctaves;
 
     public Chord(@NotNull EnharmonicSpelling root, @NotNull ChordType chordType) {
-        // TODO: this constructor is probably refactorable with Scale(EnharmonicSpelling, ChordType)
+        super.commonInitializations(root, chordType.getPitchIntervals());
         this.chordType = chordType;
-        EnharmonicSpelling r = root.apply(Accidental.NONE);
-        PitchInterval[] pitchIntervals = chordType.getPitchIntervals();
-        this.uninvertedOctaves = chordType.getBaseOctaves();
-        this.lowest = Pitch.valueOf(r.name() + "_0");
-        Pitch[] chordAtLowestOctave = new Pitch[pitchIntervals.length];
-        for (int i = 0; i < chordAtLowestOctave.length; i++) {
-            chordAtLowestOctave[i] = lowest.transposeTo(uninvertedOctaves[i]);
-        }
-        Pitch tmp = lowest.transposeTo(pitchIntervals[pitchIntervals.length - 1], true);
-        Octave range = lowest.PITCH_CLASS.OCTAVE_RANGE.NUMBER < tmp.PITCH_CLASS.OCTAVE_RANGE.NUMBER
-                ? lowest.PITCH_CLASS.OCTAVE_RANGE
-                : tmp.PITCH_CLASS.OCTAVE_RANGE;
-        this.pitches = new Pitch[range.NUMBER * pitchIntervals.length];
-        int i = 0;
-        for (Octave o = Octave.OCTAVE_0; !o.equals(range); o = o.getNext()) {
-            pitches[i] = chordAtLowestOctave[0].transposeTo(o);
-            for (int j = 1; j < pitchIntervals.length; j++) {
-                pitches[i + j] = pitches[i].transposeTo(pitchIntervals[j % pitchIntervals.length], true);
-            }
-            i += pitchIntervals.length;
-        }
-        this.highest = pitches[pitches.length - 1];
-        this.maxPlayableOctave = range.getPrevious();
-        this.name = lowest.PITCH_CLASS.ENHARMONIC_SPELLING.NAME + " " + chordType.SYMBOL;
+        this.name = super.lowestDiatonic.PITCH_CLASS.ENHARMONIC_SPELLING.NAME + chordType.SYMBOL;
     }
 
     public Chord(@NotNull PitchClass root, @NotNull ChordType chordType) {
@@ -50,47 +26,17 @@ public final class Chord extends NonSerialIntervalSet
     }
 
     @Override
-    public Pitch[] getPitchesForOctave(@NotNull Octave octave) {
-        // TODO: refactor with Scale.getPitchesForOctave(Octave)
-        Pitch test = highest.transposeTo(octave);
-        if (test == null) {
-            throw new IllegalArgumentException("Octave " + octave.NUMBER + " is out of range for " + name);
-        }
-        else if (test.OCTAVE.NUMBER > maxPlayableOctave.NUMBER) {
-            throw new IllegalArgumentException("Octave " + octave.NUMBER + " is out of range for " + name);
-        }
-        // Return the desired octave (i.e., a subarray from this.pitches)
-        Pitch[] octavePitches = new Pitch[this.chordType.length()];
-        System.arraycopy(this.pitches, octave.NUMBER * octavePitches.length, octavePitches, 0, octavePitches.length);
-        return octavePitches;
-    }
-
-    @Override
-    public boolean isTransposableTo(@NotNull PitchInterval pitchInterval, boolean direction) {
-        // TODO: refactor with Scale.isTransposableTo(PitchInterval, boolean)
-        return highest.transposeTo(pitchInterval, direction) != null;
-    }
-
-    @Override
     public void transposeTo(@NotNull PitchInterval pitchInterval, boolean direction) {
-        // TODO: refactor with Scale.transposeTo(PitchInterval, boolean)
-        if (isTransposableTo(pitchInterval, direction)) {
-            for (Pitch p : pitches) p.transposeTo(pitchInterval, direction);
-        }
+        Pitch lowestTransposed = super.lowestDiatonic.transposeTo(pitchInterval, direction);
+        super.commonInitializations(lowestTransposed.PITCH_CLASS.ENHARMONIC_SPELLING, chordType.getPitchIntervals());
+        this.name = super.lowestDiatonic.PITCH_CLASS.ENHARMONIC_SPELLING.NAME + chordType.SYMBOL;
     }
 
     @Override
-    public boolean isTransposableTo(@NotNull PitchClass pitchClass, @NotNull Octave octave) {
-        // TODO: refactor with Scale.isTransposableTo(PitchClass, Octave)
-        return highest.transposeTo(pitchClass, octave) != null;
-    }
-
-    @Override
-    public void transposeTo(@NotNull PitchClass pitchClass, @NotNull Octave octave) {
-        // TODO: refactor with Scale.transposeTo(PitchClass, Octave)
-        if (isTransposableTo(pitchClass, octave)) {
-            for (Pitch p : pitches) p.transposeTo(pitchClass, octave);
-        }
+    public void transposeTo(@NotNull PitchClass pitchClass) {
+        Pitch lowestTransposed = super.lowestDiatonic.transposeTo(pitchClass, lowestDiatonic.OCTAVE);
+        super.commonInitializations(lowestTransposed.PITCH_CLASS.ENHARMONIC_SPELLING, chordType.getPitchIntervals());
+        this.name = super.lowestDiatonic.PITCH_CLASS.ENHARMONIC_SPELLING.NAME + chordType.SYMBOL;
     }
 
     @Override

--- a/src/chordinnate/musictheory/pitch/interval/set/IntervalSet.java
+++ b/src/chordinnate/musictheory/pitch/interval/set/IntervalSet.java
@@ -1,17 +1,53 @@
 package chordinnate.musictheory.pitch.interval.set;
 
+import chordinnate.musictheory.general.Accidental;
 import chordinnate.musictheory.pitch.Pitch;
 import chordinnate.musictheory.pitch.interval.Octave;
+import chordinnate.musictheory.pitch.interval.PitchInterval;
+import chordinnate.musictheory.pitch.notation.EnharmonicSpelling;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
 
 /**
  * Created by Joseph on 7/15/16.
  */
 public abstract class IntervalSet {
+    EnumMap<Octave, Pitch[]> pitchesByOctave;
+    Pitch lowestDiatonic, highestDiatonic;
     Octave maxPlayableOctave;
-    Pitch[] pitches;
-    Pitch lowest, highest;
     String name;
 
-    public abstract Pitch[] getPitchesForOctave(@NotNull Octave octave);
+    void commonInitializations(EnharmonicSpelling root, PitchInterval[] pitchIntervals) {
+        this.pitchesByOctave = new EnumMap<>(Octave.class);
+        this.lowestDiatonic = Pitch.valueOf(root.apply(Accidental.NONE).name() + "_0");
+        Pitch lastKnownValidPitch = lowestDiatonic;
+        for (Octave octave : Octave.values()) {
+            ArrayList<Pitch> pitchesAtCurrentOctave = new ArrayList<>(pitchIntervals.length);
+            if (lowestDiatonic.isTransposableTo(octave)) {
+                Pitch lowestDiatonicAtOctave = lowestDiatonic.transposeTo(octave);
+                pitchesAtCurrentOctave.add(lowestDiatonicAtOctave);
+                for (int i = 1; i < pitchIntervals.length; i++) {
+                    if (lowestDiatonicAtOctave.isTransposableTo(pitchIntervals[i], true)) {
+                        lastKnownValidPitch = lowestDiatonicAtOctave.transposeTo(pitchIntervals[i], true);
+                        pitchesAtCurrentOctave.add(lastKnownValidPitch);
+                    }
+                }
+                Pitch[] ps = new Pitch[pitchesAtCurrentOctave.size()];
+                pitchesByOctave.put(octave, pitchesAtCurrentOctave.toArray(ps));
+            }
+        }
+        this.highestDiatonic = lastKnownValidPitch;
+        this.maxPlayableOctave = pitchesByOctave.get(highestDiatonic.OCTAVE) == null
+                ? highestDiatonic.OCTAVE.getPrevious()
+                : highestDiatonic.OCTAVE;
+    }
+
+    public Pitch[] getPitchesForOctave(@NotNull Octave octave) {
+        // Return the desired octave (i.e., a subarray from this.pitches)
+        Pitch[] source = pitchesByOctave.get(octave), destination = new Pitch[source.length];
+        System.arraycopy(source, 0, destination, 0, destination.length);
+        return destination;
+    }
 }

--- a/src/chordinnate/musictheory/pitch/interval/set/TransposableIntervalSet.java
+++ b/src/chordinnate/musictheory/pitch/interval/set/TransposableIntervalSet.java
@@ -2,19 +2,10 @@ package chordinnate.musictheory.pitch.interval.set;
 
 import chordinnate.musictheory.pitch.PitchClass;
 import chordinnate.musictheory.pitch.Transposable;
-import chordinnate.musictheory.pitch.interval.Octave;
 import chordinnate.musictheory.pitch.interval.PitchInterval;
 import org.jetbrains.annotations.NotNull;
 
 interface TransposableIntervalSet extends Transposable {
-    /**
-     * Checks the validity of a transposition to the specified PitchInterval and direction.
-     * @param pitchInterval the desired PitchInterval to transpose to
-     * @param direction the direction of transposition (true = up; false = down)
-     * @return whether the desired transposition is valid
-     */
-    boolean isTransposableTo(@NotNull PitchInterval pitchInterval, boolean direction);
-
     /**
      * Performs a transposition to the specified PitchInterval in the specified direction,
      * with side effects to the IntervalSet.
@@ -24,19 +15,9 @@ interface TransposableIntervalSet extends Transposable {
     void transposeTo(@NotNull PitchInterval pitchInterval, boolean direction);
 
     /**
-     * Checks the validity of a transposition to the specified PitchClass and Octave.
-     * @param pitchClass the desired PitchClass to transpose to
-     * @param octave the desired Octave to transpose to
-     * @return whether the desired transposition is valid
-     */
-    boolean isTransposableTo(@NotNull PitchClass pitchClass, @NotNull Octave octave);
-
-    /**
-     * Performs a transposition to the specified PitchClass and Octave,
+     * Performs a transposition to the specified PitchClass,
      * with side effects to the IntervalSet.
      * @param pitchClass the desired PitchClass to transpose to
-     * @param octave the desired Octave to transpose to
-     * @return an instance of the implementing Enum that is representative of the transposition
      */
-    void transposeTo(@NotNull PitchClass pitchClass, @NotNull Octave octave);
+    void transposeTo(@NotNull PitchClass pitchClass);
 }

--- a/test/chordinnate/musictheory/pitch/interval/set/TestChord.java
+++ b/test/chordinnate/musictheory/pitch/interval/set/TestChord.java
@@ -1,7 +1,9 @@
 package chordinnate.musictheory.pitch.interval.set;
 
 import chordinnate.musictheory.pitch.Pitch;
+import chordinnate.musictheory.pitch.PitchClass;
 import chordinnate.musictheory.pitch.interval.Octave;
+import chordinnate.musictheory.pitch.interval.PitchInterval;
 import chordinnate.musictheory.pitch.notation.EnharmonicSpelling;
 import org.junit.Test;
 
@@ -13,41 +15,37 @@ import static org.junit.Assert.*;
  */
 public class TestChord {
     @Test
-    public void getPitchesForOctave() throws Exception {
-        // TODO
-    }
-
-    @Test
-    public void isTransposableToPitchInterval() throws Exception {
-        // TODO
+    public void sanityCheck() throws Exception {
+        // Basic arbitrary testing
+        verifyChord(new Chord(C, ChordType.MAJOR), C, E, G);
+        verifyChord(new Chord(F, ChordType.MAJOR), F, A, C);
+        verifyChord(new Chord(F, ChordType.MAJOR_SEVEN), F, A, C, E);
+        verifyChord(new Chord(F, ChordType.SEVEN), F, A, C, E_FLAT);
+        verifyChord(new Chord(A_FLAT, ChordType.MINOR), A_FLAT, C_FLAT, E_FLAT);
+        verifyChord(new Chord(C, ChordType.DIMINISHED), C, E_FLAT, G_FLAT);
     }
 
     @Test
     public void transposeToPitchInterval() throws Exception {
-        // TODO
-    }
-
-    @Test
-    public void isTransposableToPitchClass() throws Exception {
-        // TODO
+        Chord transposed = new Chord(C, ChordType.MAJOR);
+        transposed.transposeTo(PitchInterval.MAJOR_SECOND, true);
+        verifyChord(transposed, D, F_SHARP, A);
+        transposed.transposeTo(PitchInterval.MAJOR_SECOND, false);
+        verifyChord(transposed, C, E, G);
     }
 
     @Test
     public void transposeToPitchClass() throws Exception {
-        // TODO
+        Chord transposed = new Chord(C, ChordType.MAJOR);
+        transposed.transposeTo(PitchClass.D);
+        verifyChord(transposed, D, F_SHARP, A);
+        transposed.transposeTo(PitchClass.C);
+        verifyChord(transposed, C, E, G);
     }
 
     @Test
     public void invert() throws Exception {
         // TODO
-    }
-
-    @Test
-    public void verifyChord() throws Exception {
-        this.verifyChord(new Chord(C, ChordType.MAJOR), C, E, G);
-        this.verifyChord(new Chord(F, ChordType.MAJOR), F, A, C);
-        this.verifyChord(new Chord(F, ChordType.MAJOR_SEVEN), F, A, C, E);
-        this.verifyChord(new Chord(F, ChordType.SEVEN), F, A, C, E_FLAT);
     }
 
     /**
@@ -60,15 +58,18 @@ public class TestChord {
                 lowPitches = chord.getPitchesForOctave(Octave.OCTAVE_0),
                 highPitches = chord.getPitchesForOctave(chord.maxPlayableOctave);
 
-        assertEquals("Chord length is not the expected length", chord.chordType.length(), expected.length);
+        assertEquals("Chord length is not the expected length (bad test args?)", chord.chordType.length(), expected.length);
 
-        assertEquals(lowPitches.length, highPitches.length);
-        int range = lowPitches.length;
+        int lowRange = lowPitches.length, highRange = highPitches.length;
 
-        for (int i = 0; i < range; i++) {
+        for (int i = 0; i < lowRange; i++) {
             assertEquals(expected[i], lowPitches[i].PITCH_CLASS.ENHARMONIC_SPELLING);
+        }
+        for (int i = 0; i < highRange; i++) {
             assertEquals(expected[i], highPitches[i].PITCH_CLASS.ENHARMONIC_SPELLING);
         }
+
+        assertEquals(chord.lowestDiatonic.PITCH_CLASS.ENHARMONIC_SPELLING.NAME + chord.chordType.SYMBOL, chord.name);
     }
 
 }

--- a/test/chordinnate/musictheory/pitch/interval/set/TestScale.java
+++ b/test/chordinnate/musictheory/pitch/interval/set/TestScale.java
@@ -1,7 +1,9 @@
 package chordinnate.musictheory.pitch.interval.set;
 
 import chordinnate.musictheory.pitch.Pitch;
+import chordinnate.musictheory.pitch.PitchClass;
 import chordinnate.musictheory.pitch.interval.Octave;
+import chordinnate.musictheory.pitch.interval.PitchInterval;
 import chordinnate.musictheory.pitch.notation.EnharmonicSpelling;
 import org.junit.Test;
 
@@ -13,32 +15,8 @@ import static org.junit.Assert.*;
  */
 public class TestScale {
     @Test
-    public void getPitchesForOctave() throws Exception {
-        // TODO
-    }
-
-    @Test
-    public void isTransposableToPitchInterval() throws Exception {
-        // TODO
-    }
-
-    @Test
-    public void transposeToPitchInterval() throws Exception {
-        // TODO
-    }
-
-    @Test
-    public void isTransposableToPitchClass() throws Exception {
-        // TODO
-    }
-
-    @Test
-    public void transposeToPitchClass() throws Exception {
-        // TODO
-    }
-
-    @Test
-    public void verifyScale() throws Exception {
+    public void sanityCheck() throws Exception {
+        // Basic arbitrary testing
         verifyScale(new Scale(C, ScaleType.MAJOR), C, D, E, F, G, A, B);
         verifyScale(new Scale(F_SHARP, ScaleType.MAJOR), F_SHARP, G_SHARP, A_SHARP, B, C_SHARP, D_SHARP, E_SHARP);
         verifyScale(new Scale(G, ScaleType.MAJOR), G, A, B, C, D, E, F_SHARP);
@@ -46,6 +24,24 @@ public class TestScale {
         verifyScale(new Scale(C, ScaleType.HARMONIC_MINOR), C, D, E_FLAT, F, G, A_FLAT, B);
         verifyScale(new Scale(B_FLAT, ScaleType.HARMONIC_MINOR), B_FLAT, C, D_FLAT, E_FLAT, F, G_FLAT, A);
         verifyScale(new Scale(C, ScaleType.BLUES), C, E_FLAT, F, F_SHARP, G, B_FLAT);
+    }
+
+    @Test
+    public void transposeToPitchInterval() throws Exception {
+        Scale transposed = new Scale(C, ScaleType.MAJOR);
+        transposed.transposeTo(PitchInterval.MAJOR_SECOND, true);
+        verifyScale(transposed, D, E, F_SHARP, G, A, B, C_SHARP);
+        transposed.transposeTo(PitchInterval.MAJOR_SECOND, false);
+        verifyScale(transposed, C, D, E, F, G, A, B);
+    }
+
+    @Test
+    public void transposeToPitchClass() throws Exception {
+        Scale transposed = new Scale(C, ScaleType.MAJOR);
+        transposed.transposeTo(PitchClass.D);
+        verifyScale(transposed, D, E, F_SHARP, G, A, B, C_SHARP);
+        transposed.transposeTo(PitchClass.C);
+        verifyScale(transposed, C, D, E, F, G, A, B);
     }
 
     /**
@@ -58,14 +54,17 @@ public class TestScale {
                 lowPitches = scale.getPitchesForOctave(Octave.OCTAVE_0),
                 highPitches = scale.getPitchesForOctave(scale.maxPlayableOctave);
 
-        assertEquals("Scale length is not the expected length", scale.scaleType.length(), expected.length);
+        assertEquals("Scale length is not the expected length (bad test args?)", scale.scaleType.length(), expected.length);
 
-        assertEquals(lowPitches.length, highPitches.length);
-        int range = lowPitches.length;
+        int lowRange = lowPitches.length, highRange = highPitches.length;
 
-        for (int i = 0; i < range; i++) {
+        for (int i = 0; i < lowRange; i++) {
             assertEquals(expected[i], lowPitches[i].PITCH_CLASS.ENHARMONIC_SPELLING);
+        }
+        for (int i = 0; i < highRange; i++) {
             assertEquals(expected[i], highPitches[i].PITCH_CLASS.ENHARMONIC_SPELLING);
         }
+
+        assertEquals(scale.lowestDiatonic.PITCH_CLASS.ENHARMONIC_SPELLING.NAME + " " + scale.scaleType.NAME, scale.name);
     }
 }


### PR DESCRIPTION
- refactored common initialization stuff from Chord and Scale into
IntervalSet

- removed unneeded interface methods from TransposableIntervalSet

- removed Octave as an argument for transposeTo(PitchClass), because
it’s not necessary to provide one under the current implementation

- added a clarifying “else” at the bottom of the big “if” of
Pitch.transposeTo(PitchInterval, boolean)

- updated TestScale and TestChord